### PR TITLE
Fix the order of i18n:attributes values to match Chameleon

### DIFF
--- a/src/lingua/extractors/tests/test_xml.py
+++ b/src/lingua/extractors/tests/test_xml.py
@@ -50,7 +50,7 @@ class ExtractTests(unittest.TestCase):
         snippet = """\
                 <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
                       i18n:domain="lingua">
-                  <dummy i18n:attributes="msg_title title" title="test tïtle"/>
+                  <dummy i18n:attributes="title msg_title" title="test tïtle"/>
                 </html>
                 """
         self.assertEqual(self.extract(snippet),
@@ -80,7 +80,7 @@ class ExtractTests(unittest.TestCase):
         snippet = """\
                 <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
                       i18n:domain="lingua">
-                  <dummy i18n:attributes="msg_title title; msg_alt alt"
+                  <dummy i18n:attributes="title msg_title; alt msg_alt"
                          title="test titlé" alt="test ålt"/>
                 </html>
                 """

--- a/src/lingua/extractors/xml.py
+++ b/src/lingua/extractors/xml.py
@@ -120,7 +120,7 @@ class XmlExtractor(object):
                     self.addMessage(attributes[msgid])
                 else:
                     try:
-                        (msgid, attr) = msgid.split()
+                        (attr, msgid) = msgid.split()
                     except ValueError:
                         continue
                     if attr not in attributes:


### PR DESCRIPTION
Previously, it was expected that when providing both the attribute name and
the messsage id the first value be the message id and the second one the name
of the attribute.

However, at least the Chameleon implementation of ZPT implements this order
differently (and IIRC the zope.pagetemplate does the same) requiring the
first item to be the name of the attribute and the second (optional) one
the message id.

See http://pagetemplates.org/docs/latest/reference.html#i18n-attributes
for details.
