### PR TITLE
Use the same whitespace regex as chameleon

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -4,8 +4,9 @@ Changelog
 1.6 - Unreleased
 -------------------
 
-- ...
-
+- Use the same whitespace regex as chameleon, i.e. \s+
+  This meant that msgids did not match when a single non-space newline
+  character was in a msgid.
 
 1.5 - April 1, 2013
 -------------------

--- a/src/lingua/extractors/xml.py
+++ b/src/lingua/extractors/xml.py
@@ -9,7 +9,7 @@ from lingua.extractors.python import PythonExtractor
 
 
 class TranslateContext(object):
-    WHITESPACE = re.compile(u"\s{2,}")
+    WHITESPACE = re.compile(u"\s+")
     EXPRESSION = re.compile(u"\s*\${[^}]*}\s*")
 
     def __init__(self, msgid, lineno, i18n_prefix):


### PR DESCRIPTION
This meant that msgids did not match when a single non-space newline character was in a msgid.

Admittedlythis could be fixed also in chameleon, but it seemed that keeping newlines out of .po files was desirable.

I did not run any automated tests for this change. Couldn't find a tox.ini and setup.py test did not work.
