### PR TITLE
structure/text prefix for tal:content/replace

### DIFF
--- a/src/lingua/extractors/xml.py
+++ b/src/lingua/extractors/xml.py
@@ -22,6 +22,7 @@ def _open(filename):
 
 
 ENGINE_PREFIX = re.compile(r'^\s*([a-z\-_]+):\s*')
+STRUCTURE_PREFIX = re.compile(r'\s*(structure|text)\s+(.*)')
 WHITESPACE = re.compile(u"\s+")
 EXPRESSION = re.compile(u"\s*\${(.*?)}\s*")
 UNDERSCORE_CALL = re.compile("_\(.*\)")
@@ -165,6 +166,9 @@ class Extractor(ElementProgram):
             if attribute[1] in ['content', 'replace']:
                 (engine, value) = get_tales_engine(value)
                 if engine == 'python':
+                    m = STRUCTURE_PREFIX.match(value)
+                    if m is not None:
+                        value = m.group(2)
                     self._assert_valid_python(value)
                     yield value
             if attribute[1] == 'define':

--- a/tests/extractors/test_xml.py
+++ b/tests/extractors/test_xml.py
@@ -448,3 +448,16 @@ class Test_get_python_expression(object):
         assert list(get_python_expressions(
             '''${resource_url(_query={'one': 'one'})}''')) == \
             ['''resource_url(_query={'one': 'one'})''']
+
+
+@pytest.mark.usefixtures('fake_source')
+def test_ignore_structure_in_replace():
+    global source
+    source = b'''\
+                <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+                      i18n:domain="lingua">
+                  <dummy tal:replace="structure _('foo')">Dummy</dummy>
+                </html>
+                '''
+    messages = list(extract_xml('filename', _options()))
+    assert messages[0].msgid == u'foo'


### PR DESCRIPTION
Strip optional structure or text prefix for tal:content, tal:replace attributes.

Refs #26.
