### PR TITLE
Support carriage return in tal:define.

### DIFF
--- a/src/lingua/extractors/xml.py
+++ b/src/lingua/extractors/xml.py
@@ -175,6 +175,7 @@ class Extractor(ElementProgram):
                 for (scope, var, value) in parse_defines(value):
                     (engine, value) = get_tales_engine(value)
                     if engine == 'python':
+                        value = '(%s)' % value
                         self._assert_valid_python(value)
                         yield value
             elif attribute[1] == 'repeat':

--- a/tests/extractors/test_xml.py
+++ b/tests/extractors/test_xml.py
@@ -461,3 +461,17 @@ def test_ignore_structure_in_replace():
                 '''
     messages = list(extract_xml('filename', _options()))
     assert messages[0].msgid == u'foo'
+
+
+@pytest.mark.usefixtures('fake_source')
+def test_carriage_return_in_define():
+    global source
+    source = b'''\
+                <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+                      i18n:domain="lingua">
+                  <dummy tal:define="foo True or
+                                     _('foo')">Dummy</dummy>
+                </html>
+                '''
+    messages = list(extract_xml('filename', _options()))
+    assert messages[0].msgid == u'foo'


### PR DESCRIPTION
By enclosing the value definition in parentheses, python will properly parse the line break.

Fixes #34.
