### PR TITLE
Fix multiline tal:replace and tal:content statements

### DIFF
--- a/src/lingua/extractors/xml.py
+++ b/src/lingua/extractors/xml.py
@@ -22,7 +22,7 @@ def _open(filename):
 
 
 ENGINE_PREFIX = re.compile(r'^\s*([a-z\-_]+):\s*')
-STRUCTURE_PREFIX = re.compile(r'\s*(structure|text)\s+(.*)')
+STRUCTURE_PREFIX = re.compile(r'\s*(structure|text)\s+(.*)', re.DOTALL)
 WHITESPACE = re.compile(u"\s+")
 EXPRESSION = re.compile(u"\s*\${(.*?)}\s*")
 UNDERSCORE_CALL = re.compile("_\(.*\)")
@@ -169,6 +169,7 @@ class Extractor(ElementProgram):
                     m = STRUCTURE_PREFIX.match(value)
                     if m is not None:
                         value = m.group(2)
+                    value = '(%s)' % value
                     self._assert_valid_python(value)
                     yield value
             if attribute[1] == 'define':

--- a/tests/extractors/test_xml.py
+++ b/tests/extractors/test_xml.py
@@ -461,3 +461,31 @@ def test_ignore_structure_in_replace():
                 '''
     messages = list(extract_xml('filename', _options()))
     assert messages[0].msgid == u'foo'
+
+
+@pytest.mark.usefixtures('fake_source')
+def test_multiline_replace():
+    global source
+    source = b'''\
+                <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+                      i18n:domain="lingua">
+                  <dummy tal:replace="True or
+                                      _('foo')">Dummy</dummy>
+                </html>
+                '''
+    messages = list(extract_xml('filename', _options()))
+    assert messages[0].msgid == u'foo'
+
+
+@pytest.mark.usefixtures('fake_source')
+def test_multiline_replace_with_structure():
+    global source
+    source = b'''\
+                <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+                      i18n:domain="lingua">
+                  <dummy tal:replace="structure True or
+                                      _('foo')">Dummy</dummy>
+                </html>
+                '''
+    messages = list(extract_xml('filename', _options()))
+    assert messages[0].msgid == u'foo'


### PR DESCRIPTION
Surround tal:replace / tal:content value in parenthesis to allow parsing multi-line statements.
