### PR TITLE
Fix tal:repeat with multiple assignment

### DIFF
--- a/src/lingua/extractors/xml.py
+++ b/src/lingua/extractors/xml.py
@@ -178,7 +178,12 @@ class Extractor(ElementProgram):
                         self._assert_valid_python(value)
                         yield value
             elif attribute[1] == 'repeat':
-                (engine, value) = get_tales_engine(value.split(None, 1)[1])
+                defines = parse_defines(value)
+                if len(defines) != 1:
+                    print('Aborting due to syntax error in %s[%d]: %s' % (
+                            self.filename, self.linenumber, value))
+                scope, var, value = defines[0]
+                (engine, value) = get_tales_engine(value)
                 if engine == 'python':
                     self._assert_valid_python(value)
                     yield value

--- a/tests/extractors/test_xml.py
+++ b/tests/extractors/test_xml.py
@@ -461,3 +461,16 @@ def test_ignore_structure_in_replace():
                 '''
     messages = list(extract_xml('filename', _options()))
     assert messages[0].msgid == u'foo'
+
+
+@pytest.mark.usefixtures('fake_source')
+def test_repeat_multiple_assignment():
+    global source
+    source = b'''\
+                <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+                      i18n:domain="lingua">
+                  <dummy tal:repeat="(ix, item) [(1, _('foo'))]">Dummy</dummy>
+                </html>
+                '''
+    messages = list(extract_xml('filename', _options()))
+    assert messages[0].msgid == u'foo'


### PR DESCRIPTION
Use chameleon's parse_defines to parse the repeat statement (this is what chameleon itself does) to properly support multiple assignments.

Fixes #33.
