### PR TITLE
Fix timezone format at pot creation

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -4,7 +4,7 @@ Changelog
 2.4 - Unreleased
 -------------------
 
-- ...
+- Fix timezone format at pot creation (remove colon).
 
 
 2.3 - June 13, 2014

--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -31,7 +31,7 @@ def po_timestamp():
     return '%s%s%s' % (
         time.strftime('%Y-%m-%d %H:%M', local),
         '-' if offset < 0 else '+',
-        time.strftime('%H:%M', time.gmtime(abs(offset))))
+        time.strftime('%H%M', time.gmtime(abs(offset))))
 
 
 class POEntry(polib.POEntry):


### PR DESCRIPTION
Remove colon because it breaks Babel when generating .po files
