### PR TITLE
_extract_python ignores firstline parameter.

### DIFF
--- a/src/lingua/extractors/python.py
+++ b/src/lingua/extractors/python.py
@@ -99,7 +99,7 @@ def _extract_python(filename, source, options, firstline=0):
         flags = []
         check_c_format(msg[2], flags)
         check_python_format(msg[2], flags)
-        yield Message(msg[1], msg[2], msg[3], flags, msg[4], u'', (filename, node.lineno))
+        yield Message(msg[1], msg[2], msg[3], flags, msg[4], u'', (filename, firstline + node.lineno))
 
 
 class PythonExtractor(Extractor):


### PR DESCRIPTION
The `firstline` parameter is not relevant when extracting messages from a Python (.py) file, however it is required to get correct line numbers when extracting messages from files embedding fragments of Python code, e.g. Mako templates (without it, all messages appear to be located at line # 1)