### PR TITLE
Replace stripped line number with empty string

### DIFF
--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -140,7 +140,7 @@ def strip_linenumbers(entry):
     for location, line in entry.occurrences:
         if location in seen:
             continue
-        occurrences.append((location, None))
+        occurrences.append((location, ''))
         seen.add(location)
     entry.occurrences = occurrences
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,6 +2,14 @@ import polib
 from lingua.extract import POEntry
 from lingua.extract import POFile
 from lingua.extract import identical
+from lingua.extract import strip_linenumbers
+
+
+STRIPPED_LINENUMBERS_PO = """\
+#: file.txt
+msgid "A"
+msgstr ""
+"""
 
 
 class Test_identical:
@@ -50,4 +58,12 @@ class Test_identical:
         a[0]._comments.append(u'Comment one')
         b.append(polib.POEntry(msgid=u'id'))
         b[0].comment = u'Comment\none'
+        assert identical(a, b)
+
+    def test_strip_linenumbers(self):
+        a = POFile()
+        b = polib.pofile(STRIPPED_LINENUMBERS_PO)
+        a.append(POEntry(msgid=u'A', occurrences=[('file.txt', '1')]))
+        for entry in a:
+            strip_linenumbers(entry)
         assert identical(a, b)


### PR DESCRIPTION
Stripped line numbers were replaced with None. Whereas polib expects
line numbers to be strings. The comparison with a catalog generated by
polib would then fail.