### PR TITLE
show language in compilation process

### DIFF
--- a/docs/examples/i18n.sh
+++ b/docs/examples/i18n.sh
@@ -35,6 +35,9 @@ if [ $# -eq 0 ]; then
 
     echo "Compile message catalogs"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/*.po; do
+        lg=${po##$LOCALES_PATH/}
+        lg=${lg%%/LC_MESSAGES/*}
+        echo -n "$lg: "
         msgfmt --statistics -o "${po%.*}.mo" "$po"
     done
 


### PR DESCRIPTION
Makes it much easier to see, what's going on for a certain language:
```
LANG=C ./i18n.sh
Extract messages
No changes found - not replacing deform/locale/deform.pot
Update translations
.......... done.
......... done.
......... done.
........ done.
......... done.
........ done.
........ done.
......... done.
......... done.
......... done.
......... done.
......... done.
......... done.
......... done.
........ done.
......... done.
Compile message catalogs
cs: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
da: 11 translated messages, 1 fuzzy translation, 14 untranslated messages.
de: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
el: 24 translated messages, 2 untranslated messages.
es: 11 translated messages, 1 fuzzy translation, 14 untranslated messages.
fi: 25 translated messages, 1 untranslated message.
fr: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
it: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
ja: 25 translated messages, 1 untranslated message.
nl: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
pl: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
pt: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
pt_BR: 11 translated messages, 1 fuzzy translation, 14 untranslated messages.
ru: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
sv: 18 translated messages, 2 fuzzy translations, 6 untranslated messages.
zh: 19 translated messages, 2 fuzzy translations, 5 untranslated messages.
zh_CN: 26 translated messages.
zh_Hans: 26 translated messages.
```