### PR TITLE
Fix Pytest4.x compatibility error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bdist_wheel]
 universal=1
 
-[pytest]
+[tool:pytest]
 testpaths = tests
 norecursedirs = .git tmp* .eggs bin build include lib share src


### PR DESCRIPTION
According to pytest docs:

```
[pytest] section in setup.cfg files

Removed in version 4.0.

[pytest] sections in setup.cfg files should now be named [tool:pytest] to
avoid conflicts with other distutils commands.
```