### PR TITLE
Skip function definitions in Python extractor

### DIFF
--- a/src/lingua/extractors/python.py
+++ b/src/lingua/extractors/python.py
@@ -232,6 +232,11 @@ class PythonParser(object):
             self.handler = self.state_in_keyword
             self.keyword = KEYWORDS.get(token, None)
             self.lineno = location[0]
+        elif token_type == tokenize.NAME and token == 'def':
+            self.handler = self.state_skip_function_def
+
+    def state_skip_function_def(self, token_type, token, location, token_stream):
+        self.handler = self.state_skip
 
     def state_in_keyword(self, token_type, token, location, token_stream):
         """Check if the keyword is used in a proper function call."""


### PR DESCRIPTION
When defining a function with the same name as a keyword (e.g. to perform some preprocessing before forwarding to the translation engine), pot-create tries and fails to extract the parameter names as arguments. 

With this PR, it will skip the first token following the `def` keyword (i.e. the function name). Calls to a translation function as a default value will still work.