### PR TITLE
Skip Babel extractors if dependencies are missing

### DIFF
--- a/src/lingua/extractors/__init__.py
+++ b/src/lingua/extractors/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from pkg_resources import DistributionNotFound
 from pkg_resources import working_set
 import abc
 import collections
@@ -149,10 +150,16 @@ class Extractor(object):
 
 def register_extractors():
     for entry_point in working_set.iter_entry_points('lingua.extractors'):
-        extractor = entry_point.load(require=True)
-        if not issubclass(extractor, Extractor):
-            raise ValueError(
-                u'Registered extractor must derive from ``Extractor``')
-        EXTRACTORS[entry_point.name] = extractor()
-        for extension in extractor.extensions:
-            EXTENSIONS[extension] = entry_point.name
+        try:
+            extractor = entry_point.load(require=True)
+        except DistributionNotFound:
+            # skip this entry point since at least one required dependency can
+            # not be found
+            extractor = None
+        if extractor:
+            if not issubclass(extractor, Extractor):
+                raise ValueError(
+                    u'Registered extractor must derive from ``Extractor``')
+            EXTRACTORS[entry_point.name] = extractor()
+            for extension in extractor.extensions:
+                EXTENSIONS[extension] = entry_point.name


### PR DESCRIPTION
The Babel message extractors (plugins) should not be loaded if they
depend on thir party projects that are not available.

GitHub: #94