### PR TITLE
Update TravisCI config to current Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
   - pypy
 install:
   - pip install -e '.[tests]'


### PR DESCRIPTION
Python's current versions are 2.7, 3.5, 3.6, and 3.7. The versions
2.6, 3.3, and 3.4 are old versions that do not receive support
anymore.

It is difficult to test against Python's older versions in Travis CI.