### PR TITLE
docs: Fix simple typo, translateable -> translatable

### DIFF
--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -385,7 +385,7 @@ def main(
     package_version,
     msgid_bugs_address,
 ):
-    "Extract translateable strings."
+    "Extract translatable strings."
     directory = list(directory)
     register_extractors()
     register_babel_plugins()


### PR DESCRIPTION
There is a small typo in src/lingua/extract.py.

Should read `translatable` rather than `translateable`.

