### PR TITLE
Fix list-files

### DIFF
--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -114,7 +114,7 @@ def list_files(files_from, sources):
         for filename in files_from:
             if filename.startswith("#") or not filename.strip():
                 continue
-            yield filename
+            yield filename.rstrip()
     for file in sources:
         if os.path.isfile(file):
             yield file


### PR DESCRIPTION
Fix file not found error with --list-files due to a \n appended to each filename.

Fixes: https://github.com/wichert/lingua/issues/103