### PR TITLE
Include 'LANGUAGE' in the default metadata.

### DIFF
--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -166,7 +166,7 @@ def create_catalog(
     catalog.metadata["PO-Revision-Date"] = "YEAR-MO-DA HO:MI+ZONE"
     catalog.metadata["Last-Translator"] = "FULL NAME <EMAIL@ADDRESS>"
     catalog.metadata["Language-Team"] = "LANGUAGE <LL@li.org>"
-    catalog.metadata["Language"] = ""
+    catalog.metadata["Language"] = "LANGUAGE"
     catalog.metadata["MIME-Version"] = "1.0"
     catalog.metadata["Content-Type"] = "text/plain; charset=UTF-8"
     catalog.metadata["Content-Transfer-Encoding"] = "8bit"


### PR DESCRIPTION
While building the '.po' with Babel (pybabel) it complains about this field
being empty:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File ".venv/lib/python3.10/site-packages/babel/messages/frontend.py", line 929, in main
        return CommandLineInterface().run(sys.argv)
      File ".venv/lib/python3.10/site-packages/babel/messages/frontend.py", line 853, in run
        return cmdinst.run()
      File ".venv/lib/python3.10/site-packages/babel/messages/frontend.py", line 622, in run
        catalog = read_po(infile, locale=self.locale)
      File ".venv/lib/python3.10/site-packages/babel/messages/pofile.py", line 381, in read_po
        parser.parse(fileobj)
      File ".venv/lib/python3.10/site-packages/babel/messages/pofile.py", line 308, in parse
        self._process_comment(line)
      File ".venv/lib/python3.10/site-packages/babel/messages/pofile.py", line 267, in _process_comment
        self._finish_current_message()
      File ".venv/lib/python3.10/site-packages/babel/messages/pofile.py", line 204, in _finish_current_message
        self._add_message()
      File ".venv/lib/python3.10/site-packages/babel/messages/pofile.py", line 198, in _add_message
        self.catalog[msgid] = message
      File ".venv/lib/python3.10/site-packages/babel/messages/catalog.py", line 628, in __setitem__
        self.mime_headers = _parse_header(message.string).items()
      File ".venv/lib/python3.10/site-packages/babel/messages/catalog.py", line 429, in _set_mime_headers
        self._set_locale(value)
      File ".venv/lib/python3.10/site-packages/babel/messages/catalog.py", line 317, in _set_locale
        self._locale = Locale.parse(locale)
      File ".venv/lib/python3.10/site-packages/babel/core.py", line 268, in parse
        parts = parse_locale(identifier, sep=sep)
      File ".venv/lib/python3.10/site-packages/babel/core.py", line 1094, in parse_locale
        raise ValueError('expected only letters, got %r' % lang)
    ValueError: expected only letters, got ''