### PR TITLE
docs: fix simple typo, preceeding -> preceding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ Comments are inherited, so you can put them on a parent element as well.
 
 For Python code you can tell lingua to include comments by using the
 ``--add-comments`` option. This will make Linua include all comments on the
-line(s) *immediately preceeding* (there may be no empty line in between) a
+line(s) *immediately preceding* (there may be no empty line in between) a
 translation call.
 
 ::


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `preceding` rather than `preceeding`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md