### PR TITLE
Add Python 3.12 related updates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,15 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.7", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -42,14 +42,14 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Insert version number
         run: |

--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 
 try:
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 except ImportError:
     from ConfigParser import SafeConfigParser
 import click

--- a/src/lingua/extractors/__init__.py
+++ b/src/lingua/extractors/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import print_function
-from pkg_resources import DistributionNotFound
-from pkg_resources import working_set
+
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 import abc
 import collections
 import os
@@ -162,13 +166,8 @@ class Extractor(object):
 
 
 def register_extractors():
-    for entry_point in working_set.iter_entry_points("lingua.extractors"):
-        try:
-            extractor = entry_point.load(require=True)
-        except DistributionNotFound:
-            # skip this entry point since at least one required dependency can
-            # not be found
-            extractor = None
+    for entry_point in entry_points("lingua.extractors"):
+        extractor = entry_point.load()
         if extractor:
             if not issubclass(extractor, Extractor):
                 raise ValueError("Registered extractor must derive from ``Extractor``")

--- a/src/lingua/extractors/babel.py
+++ b/src/lingua/extractors/babel.py
@@ -1,5 +1,8 @@
-from pkg_resources import DistributionNotFound
-from pkg_resources import working_set
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 from .python import KEYWORDS
 from .python import parse_keyword
 from . import EXTRACTORS
@@ -58,15 +61,10 @@ class BabelExtractor(Extractor):
 
 
 def register_babel_plugins():
-    for entry_point in working_set.iter_entry_points("babel.extractors"):
-        name = entry_point.name
-        try:
-            extractor = entry_point.load(require=True)
-        except DistributionNotFound:
-            # skip this entry point since at least one required dependency can
-            # not be found
-            extractor = None
+    for entry_point in entry_points("babel.extractors"):
+        extractor = entry_point.load()
         if extractor:
+            name = entry_point.name
             cls = type(
                 "BabelExtractor_%s" % name,
                 (BabelExtractor, object),


### PR DESCRIPTION
Resolves #109 

Add Python 3.12 related updates:
  - Use Python 3.8-3.12 for test matrix
  - Bump GH action versions
  - Fix configparser SafeConfigParser name issue (the initial one)
  - Replace pkg_resources with importlib.metadata

The 3.12 test job will fail due to a similar issue -- I'll revisit this if needed later after https://github.com/malthe/chameleon/issues/379 is addressed.


I also recommend migrating the PyPI publisher to [OIDC's short lived tokens](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi).