### PR TITLE
fixed import error on python3.12

### DIFF
--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -12,9 +12,9 @@ import tempfile
 import time
 
 try:
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser
 except ImportError:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import ConfigParser
 import click
 import polib
 from lingua.extractors import get_extractor


### PR DESCRIPTION
SafeConfigParser was removed in python 3.12. Replaced it with ConfigParser