### PR TITLE
Fix Compat for Python >= 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,17 +9,22 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.7", "3.9", "3.10"]
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
 
       - name: flake8
         uses: py-actions/flake8@v2
@@ -42,12 +47,12 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2022, Wichert Akkerman
+Copyright (c) 2010-2025, Wichert Akkerman
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/changes.rst
+++ b/changes.rst
@@ -4,6 +4,10 @@ Changelog
 4.??
 ------------------------
 
+- Add entry point loading compat code for Python >= 3.12.
+
+- Fix SafeConfigParser import for Python >= 3.12.
+
 - Update supported Python versions in pyproject.toml. This fixes `issue 104
   <https://github.com/wichert/lingua/issues/104>`_.
 
@@ -14,6 +18,7 @@ Changelog
 - Fix file not found error with ``--list-files`` due to a ``\n`` appended 
   to each filename.
   `Patch #97 <https://github.com/wichert/lingua/pull/102>`_ from Johannes Raggam.
+
 
 4.14 - November 10, 2019
 ------------------------
@@ -51,6 +56,7 @@ Changelog
 
 - Update `i18n.sh` to show language during the compilation process.
   `Patch #83 <https://github.com/wichert/lingua/pull/83>`_ from Hans-Peter Jansen.
+
 
 4.13 - January 24, 2016
 ------------------------

--- a/changes.rst
+++ b/changes.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-4.??
-------------------------
+4.16 - Unreleased
+-----------------
 
 - Add entry point loading compat code for Python >= 3.12.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ xml = "lingua.extractors.xml:ChameleonExtractor"
 zope = "lingua.extractors.xml:ZopeExtractor"
 zcml = "lingua.extractors.zcml:ZCMLExtractor"
 
-
 [project.urls]
 homepage = "https://github.com/wichert/lingua"
 tracker = "https://github.com/wichert/lingua/issues"

--- a/src/lingua/__init__.py
+++ b/src/lingua/__init__.py
@@ -1,3 +1,3 @@
 """Translation toolset"""
 
-__version__ = "4.14.0"
+__version__ = "4.16.0"

--- a/src/lingua/extract.py
+++ b/src/lingua/extract.py
@@ -14,7 +14,10 @@ import time
 try:
     from configparser import SafeConfigParser
 except ImportError:
-    from ConfigParser import SafeConfigParser
+    try:
+        from configparser import ConfigParser as SafeConfigParser
+    except ImportError:
+        from ConfigParser import SafeConfigParser
 import click
 import polib
 from lingua.extractors import get_extractor

--- a/src/lingua/extractors/__init__.py
+++ b/src/lingua/extractors/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import print_function
-from pkg_resources import DistributionNotFound
-from pkg_resources import working_set
 import abc
 import collections
 import os
 import re
 import sys
 from .compat import add_metaclass
+from .compat import EntryPointLoadError
+from .compat import iter_entry_points
+from .compat import load_entry_point
 
 
 Message = collections.namedtuple(
@@ -162,10 +163,10 @@ class Extractor(object):
 
 
 def register_extractors():
-    for entry_point in working_set.iter_entry_points("lingua.extractors"):
+    for entry_point in iter_entry_points("lingua.extractors"):
         try:
-            extractor = entry_point.load(require=True)
-        except DistributionNotFound:
+            extractor = load_entry_point(entry_point)
+        except EntryPointLoadError:
             # skip this entry point since at least one required dependency can
             # not be found
             extractor = None

--- a/src/lingua/extractors/babel.py
+++ b/src/lingua/extractors/babel.py
@@ -1,5 +1,6 @@
-from pkg_resources import DistributionNotFound
-from pkg_resources import working_set
+from .compat import EntryPointLoadError
+from .compat import iter_entry_points
+from .compat import load_entry_point
 from .python import KEYWORDS
 from .python import parse_keyword
 from . import EXTRACTORS
@@ -58,11 +59,11 @@ class BabelExtractor(Extractor):
 
 
 def register_babel_plugins():
-    for entry_point in working_set.iter_entry_points("babel.extractors"):
+    for entry_point in iter_entry_points("babel.extractors"):
         name = entry_point.name
         try:
-            extractor = entry_point.load(require=True)
-        except DistributionNotFound:
+            extractor = load_entry_point(entry_point)
+        except EntryPointLoadError:
             # skip this entry point since at least one required dependency can
             # not be found
             extractor = None

--- a/src/lingua/extractors/compat.py
+++ b/src/lingua/extractors/compat.py
@@ -1,6 +1,41 @@
 # Python compatibility support code
 # This is taken from six
 
+# Entry points compatibility for importlib.metadata vs pkg_resources
+try:
+    from importlib.metadata import entry_points
+
+    try:
+        # Python 3.10+ returns SelectableGroups with select() method
+        entry_points(group="test")
+
+        def iter_entry_points(group):
+            return entry_points(group=group)
+    except TypeError:
+        # Python 3.9 returns a dict-like object
+        def iter_entry_points(group):
+            eps = entry_points()
+            return eps.get(group, [])
+
+    # In importlib.metadata, entry_point.load() doesn't have require parameter.
+    # Missing dependencies raise ModuleNotFoundError instead of DistributionNotFound.
+    EntryPointLoadError = ModuleNotFoundError
+
+    def load_entry_point(entry_point):
+        return entry_point.load()
+
+except ImportError:
+    from pkg_resources import DistributionNotFound
+    from pkg_resources import working_set
+
+    def iter_entry_points(group):
+        return working_set.iter_entry_points(group)
+
+    EntryPointLoadError = DistributionNotFound
+
+    def load_entry_point(entry_point):
+        return entry_point.load(require=True)
+
 
 def add_metaclass(metaclass):
     """Class decorator for creating a class with a metaclass."""

--- a/tests/extractors/test_python.py
+++ b/tests/extractors/test_python.py
@@ -227,7 +227,7 @@ def test_function_argument():
     options = mock.Mock()
     options.keywords = []
     options.comment_tag = "I18N:"
-    source = u"""_('word', func('foo', 2'))"""
+    source = u"""_('word', func('foo', 2))"""
     messages = list(python_extractor("filename", options))
     assert len(messages) == 1
     assert messages[0].msgid == "word"


### PR DESCRIPTION
This adds compatibility code for loading entry points and fixing config parser import for Python >= 3.12. It also fixes tests as there was a syntax error in test_python.py
